### PR TITLE
Extend Harfbuzz api

### DIFF
--- a/examples/glfw/CMakeLists.txt
+++ b/examples/glfw/CMakeLists.txt
@@ -1,7 +1,11 @@
 cmake_minimum_required(VERSION 2.8)
 project(fontstash_es)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x -stdlib=libc++ -g -O0")
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x -stdlib=libc++ -g -O0")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++0x -g -O0")
+endif()
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLFW REQUIRED glfw3)
@@ -14,12 +18,16 @@ else()
     message(STATUS "Found GLFW ${GLFW_PREFIX}")
 endif()
 
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 list(APPEND GLFW_LDFLAGS
     "-framework OpenGL"
     "-framework Cocoa"
     "-framework IOKit"
     "-framework CoreFoundation"
     "-framework CoreVideo")
+else()
+    find_package(OpenGL REQUIRED)
+endif()
 
 include_directories(../../fontstash)
 
@@ -27,6 +35,15 @@ add_executable(glfw.out main.cpp)
 add_executable(particles.out particles.cpp)
 add_executable(colors.out colors.cpp)
 
-target_link_libraries(glfw.out ${GLFW_LDFLAGS})
-target_link_libraries(particles.out ${GLFW_LDFLAGS})
-target_link_libraries(colors.out ${GLFW_LDFLAGS})
+target_link_libraries(glfw.out ${GLFW_LDFLAGS} ${OPENGL_LIBRARIES})
+target_link_libraries(particles.out ${GLFW_LDFLAGS} ${OPENGL_LIBRARIES})
+target_link_libraries(colors.out ${GLFW_LDFLAGS} ${OPENGL_LIBRARIES})
+
+add_custom_target(copy_resources
+  COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ios/FontstashiOS/resources
+    ${CMAKE_BINARY_DIR}
+  # Make resources show up in IDE, at least this should do it
+  SOURCES ${RESOURCE_FILES})
+
+add_dependencies(glfw.out copy_resources)

--- a/examples/glfw/colors.cpp
+++ b/examples/glfw/colors.cpp
@@ -34,8 +34,10 @@ int main() {
     // init font context
     GLFONSparams params;
     params.useGLBackend = true; // if not set to true, you must provide your own gl backend
-    ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT, params, nullptr);
-    fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
+    ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT | FONS_NORMALIZE_TEX_COORDS, params, nullptr);
+    //fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
+    //fonsAddFont(ftCtx, "Arial", "/usr/share/fonts/TTF/DejaVuSans.ttf");
+    fonsAddFont(ftCtx, "Arial", "amiri-regular.ttf");
 
     // set the screen size for font context transformations
     glfonsScreenSize(ftCtx, width * dpiRatio, height * dpiRatio);

--- a/examples/glfw/main.cpp
+++ b/examples/glfw/main.cpp
@@ -1,6 +1,7 @@
 #define GLFW_INCLUDE_ES2
 #include <GLFW/glfw3.h>
 #include <cmath>
+#include <cstdio>
 
 #define GLFONS_DEBUG
 #define GLFONTSTASH_IMPLEMENTATION
@@ -9,7 +10,7 @@
 GLFWwindow* window;
 float width = 800, height = 600, dpiRatio = 1;
 
-#define NB_TEXT 5
+#define NB_TEXT 4
 
 FONScontext* ftCtx;
 fsuint textBuffer, textIds[NB_TEXT];
@@ -31,8 +32,10 @@ int main() {
     GLFONSparams params;
     params.useGLBackend = true; // if not set to true, you must provide your own gl backend
     ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT | FONS_NORMALIZE_TEX_COORDS, params, nullptr);
-    // fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
-    fonsAddFont(ftCtx, "Arial", "amiri-regular.ttf");
+    if (fonsAddFont(ftCtx, "Arial", "amiri-regular.ttf") == FONS_INVALID) {
+        printf("Can't load font\n");
+        return 0;
+    }
 
     // set the screen size for font context transformations
     glfonsScreenSize(ftCtx, width * dpiRatio, height * dpiRatio);
@@ -52,8 +55,7 @@ int main() {
     glfonsRasterize(ftCtx, textIds[1], "jumps over the lazy dog");
     fonsSetSize(ftCtx, 60.0 * dpiRatio);
     glfonsRasterize(ftCtx, textIds[2], "the quick brown fox jumps over the lazy dog");
-    glfonsRasterize(ftCtx, textIds[3], "конец konéts");
-    glfonsRasterize(ftCtx, textIds[4], "fontstash-es");
+    glfonsRasterize(ftCtx, textIds[3], "fontstash-es");
 
     for(int i = 0; i < NB_TEXT; ++i) {
         glfonsTransform(ftCtx, textIds[i], -(100.0 + i * 10.0) * dpiRatio, (100.0 + i * 50.0) * dpiRatio, 0.0, 1.0);
@@ -69,7 +71,7 @@ int main() {
         glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
         glfonsTransform(ftCtx, textIds[0], (width / 2.0) * dpiRatio, (height / 2.0) * dpiRatio, cos(t) * 0.5, cos(t) * 0.5 + 0.5);
-        glfonsTransform(ftCtx, textIds[4], (width / 2.0) * dpiRatio, (height / 2.0 - 200.0 + cos(t) * 20.0) * dpiRatio, 0.0, 1.0);
+        glfonsTransform(ftCtx, textIds[3], (width / 2.0) * dpiRatio, (height / 2.0 - 200.0 + cos(t) * 20.0) * dpiRatio, 0.0, 1.0);
 
         glfonsSetColor(ftCtx, 0x000000);
 

--- a/examples/glfw/main.cpp
+++ b/examples/glfw/main.cpp
@@ -4,7 +4,7 @@
 
 #define GLFONS_DEBUG
 #define GLFONTSTASH_IMPLEMENTATION
-#import "glfontstash.h"
+#include "glfontstash.h"
 
 GLFWwindow* window;
 float width = 800, height = 600, dpiRatio = 1;
@@ -30,8 +30,9 @@ int main() {
     // init font context
     GLFONSparams params;
     params.useGLBackend = true; // if not set to true, you must provide your own gl backend
-    ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT, params, nullptr);
-    fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
+    ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT | FONS_NORMALIZE_TEX_COORDS, params, nullptr);
+    // fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
+    fonsAddFont(ftCtx, "Arial", "amiri-regular.ttf");
 
     // set the screen size for font context transformations
     glfonsScreenSize(ftCtx, width * dpiRatio, height * dpiRatio);

--- a/examples/glfw/particles.cpp
+++ b/examples/glfw/particles.cpp
@@ -32,8 +32,10 @@ int main() {
     // init font context
     GLFONSparams params;
     params.useGLBackend = true; // if not set to true, you must provide your own gl backend
-    ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT, params, nullptr);
-    fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
+    ftCtx = glfonsCreate(512, 512, FONS_ZERO_TOPLEFT | FONS_NORMALIZE_TEX_COORDS, params, nullptr);
+    //fonsAddFont(ftCtx, "Arial", "/Library/Fonts/Arial.ttf");
+    //fonsAddFont(ftCtx, "Arial", "/usr/share/fonts/TTF/DejaVuSans.ttf");
+    fonsAddFont(ftCtx, "Arial", "amiri-regular.ttf");
 
     // set the screen size for font context transformations
     glfonsScreenSize(ftCtx, width * dpiRatio, height * dpiRatio);

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -1318,6 +1318,9 @@ static FONSglyph* fons__getGlyph(FONScontext* stash, FONSfont* font, unsigned in
     scale = fons__tt_getPixelHeightScale(&font->font, size);
     g = fons__tt_getGlyphIndex(&font->font, codepoint, fons__getState(stash)->useShaping
             && font->font.shaper != NULL);
+    if (g == 0) {
+        return NULL;
+    }
     fons__tt_buildGlyphBitmap(&font->font, g, size, scale, &advance, &lsb, &x0, &y0, &x1, &y1);
     gw = x1-x0 + pad*2;
     gh = y1-y0 + pad*2;
@@ -1576,11 +1579,6 @@ static float fons__getVertAlign(FONScontext* stash, FONSfont* font, int align, s
     return 0.0;
 }
 
-static int fons__codepointAvailable(FONScontext* stash, FONSfont* font, unsigned int codepoint)
-{
-    // TODO
-}
-
 static __inline void fons__vertices(FONScontext* stash, FONSquad q, FONSstate* state)
 {
     if (stash->params.pushQuad) {
@@ -1659,20 +1657,18 @@ bool fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char
         }
     } else {
         unsigned int utf8state = 0;
+
         if (end == NULL)
             end = str + strlen(str);
 
         for (; str != end; ++str) {
-            if (fons__decutf8(&utf8state, &codepoint, *(const unsigned char*)str)) {
+            if (fons__decutf8(&utf8state, &codepoint, *(const unsigned char*)str))
                 continue;
-            }
 
-            if (!fons__codepointAvailable(stash, font, codepoint)) {
+            if (codepoint == 0) {
                 return false;
             }
         }
-
-        return false;
     }
 
     return true;

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -1786,9 +1786,8 @@ float fonsDrawText(FONScontext* stash,
     if (invalid) {
         fons__flush(stash, 1);
         return -1.f;
-    } else {
-        return x;
     }
+    return x;
 }
 
 int fonsTextIterInit(FONScontext* stash, FONStextIter* iter,

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -248,7 +248,7 @@ void fons__tt_getFontVMetrics(FONSttFontImpl *font, int *ascent, int *descent, i
 
 float fons__tt_getPixelHeightScale(FONSttFontImpl *font, float size)
 {
-    return size / (font->font->ascender - font->font->descender);
+    return size / (float)font->font->units_per_EM;
 }
 
 int fons__tt_getGlyphIndex(FONSttFontImpl *font, int codepoint, int useShaping)
@@ -1491,18 +1491,18 @@ static void fons__getQuad(FONScontext* stash, FONSfont* font,
 
         xadv = (float)shaping->advance[it] * unitFontScale;
         yadv = (float)shaping->advance[it+1] * unitFontScale;
-        xoff = (float)shaping->offset[it] / 10.0f * unitFontScale + 1;
-        yoff = (float)shaping->offset[it+1] / 10.0f * unitFontScale + 1;
+        xoff = (float)shaping->offset[it] * unitFontScale + 1;
+        yoff = (float)shaping->offset[it+1] * unitFontScale + 1;
         q->s0 = x0 = (float)(glyph->x0+1);
         q->t0 = y0 = (float)(glyph->y0+1);
         q->s1 = x1 = (float)(glyph->x1-1);
         q->t1 = y1 = (float)(glyph->y1-1);
 
         if (stash->params.flags & FONS_NORMALIZE_TEX_COORDS) {
-          q->s0 *= stash->itw;
-          q->t0 *= stash->ith;
-          q->s1 *= stash->itw;
-          q->t1 *= stash->ith;
+            q->s0 *= stash->itw;
+            q->t0 *= stash->ith;
+            q->s1 *= stash->itw;
+            q->t1 *= stash->ith;
         }
 
         rx = *x + xoff;
@@ -1629,6 +1629,7 @@ bool fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char
         return false;
     }
 
+    short isize = (short)(state->size * 10.0f);
     useShaping = font->font.shaper != NULL && fons__getState(stash)->useShaping;
 
     if(useShaping) {
@@ -1638,6 +1639,7 @@ bool fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char
             unsigned int i, j;
             shaping->result = (FONSshapingRes*) malloc(sizeof(FONSshapingRes));
 
+            fons__tt_setPixelSize(&font->font, (float)isize / 10.0f);
             fons__hb_shape(stash, str, font);
 
             for (i = 0, j = 0; i < shaping->result->glyphCount; i++, j+=2) {

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -20,6 +20,8 @@
 #ifndef FONS_H
 #define FONS_H
 
+#include <stdbool.h>
+
 #define FONS_INVALID -1
 
 enum FONSflags {
@@ -143,7 +145,7 @@ void fonsSetFont(FONScontext* s, int font);
 // Draw text
 float fonsDrawText(FONScontext* s, float x, float y, const char* string, const char* end, const char c);
 
-int fonsTextDrawable(FONScontext* stash, const char* string, const char* end, char cacheshaping);
+bool fonsTextDrawable(FONScontext* stash, const char* string, const char* end, char cacheshaping);
 
 // Measure text
 
@@ -1627,7 +1629,7 @@ void fonsSetShaping(FONScontext* stash, void* script, void* direction, void* lan
     fons__getState(stash)->useShaping = 1;
 }
 
-int fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char cacheshaping)
+bool fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char cacheshaping)
 {
     if (stash == NULL) return -1;
 
@@ -1637,12 +1639,12 @@ int fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char 
     int useShaping;
 
     if (state->font < 0 || state->font >= stash->nfonts) {
-        return -1;
+        return false;
     }
 
     font = stash->fonts[state->font];
     if (font->data == NULL) {
-        return -1;
+        return false;
     }
 
     useShaping = font->font.shaper != NULL && fons__getState(stash)->useShaping;
@@ -1660,7 +1662,8 @@ int fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char 
                 shaping->it = j;
                 codepoint = shaping->result->codepoints[i];
                 if (codepoint == 0) {
-                    return -1;
+                    fons__clearShaping(stash);
+                    return false;
                 }
             }
 
@@ -1668,7 +1671,7 @@ int fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char 
                 fons__clearShaping(stash);
             }
         } else {
-            return -1;
+            return false;
         }
     } else {
         unsigned int utf8state = 0;
@@ -1681,14 +1684,14 @@ int fonsTextDrawable(FONScontext* stash, const char* str, const char* end, char 
             }
 
             if (!fons__codepointAvailable(stash, font, codepoint)) {
-                return -1;
+                return false;
             }
         }
 
-        return -1;
+        return false;
     }
 
-    return 1;
+    return true;
 }
 
 float fonsDrawText(FONScontext* stash,

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -20,6 +20,7 @@
 #ifndef FONS_H
 #define FONS_H
 
+#include <cstring>
 #include <stdbool.h>
 
 #define FONS_INVALID -1

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -222,6 +222,19 @@ int fons__tt_loadFont(FONScontext *context, FONSttFontImpl *font, unsigned char 
     //font->font.userdata = stash;
     ftError = FT_New_Memory_Face(ftLibrary, (const FT_Byte*)data, dataSize, 0, &font->font);
 
+    bool setcharmap = false;
+    // force USC-2
+    for(int i = 0; i < font->font->num_charmaps; i++) {
+        if (((  font->font->charmaps[i]->platform_id == 0)
+            && (font->font->charmaps[i]->encoding_id == 3))
+           || ((font->font->charmaps[i]->platform_id == 3)
+            && (font->font->charmaps[i]->encoding_id == 1))) {
+                ftError = FT_Set_Charmap(font->font, font->font->charmaps[i]);
+                setcharmap = true;
+                break;
+        }
+    }
+
     fons__tt_initShaper(font);
     return ftError == 0;
 }

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -1618,7 +1618,9 @@ float fonsDrawText(FONScontext* stash,
             for (i = 0, j = 0; i < shaping->shapingRes->glyphCount; i++, j+=2) {
                 shaping->it = j;
                 codepoint = shaping->shapingRes->codepoints[i];
-
+                if (codepoint == 0) {
+                    continue;
+                }
                 glyph = fons__getGlyph(stash, font, codepoint, isize, iblur, state->blurType);
 
                 if (glyph != NULL) {

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -22,11 +22,6 @@
 
 #define FONS_INVALID -1
 
-#ifdef FONS_USE_HARFBUZZ
-#include <hb.h>
-#include <hb-ft.h>
-#endif
-
 enum FONSflags {
     FONS_ZERO_TOPLEFT = 1,
     FONS_ZERO_BOTTOMLEFT = 2,

--- a/fontstash/fontstash.h
+++ b/fontstash/fontstash.h
@@ -243,7 +243,7 @@ int fons__tt_getGlyphIndex(FONSttFontImpl *font, int codepoint, int useShaping)
 int fons__tt_setPixelSize(FONSttFontImpl* font, float size)
 {
     FT_Error ftError;
-    ftError = FT_Set_Pixel_Sizes(font->font, 0, (FT_UInt)(size * (float)font->font->units_per_EM / (float)(font->font->ascender - font->font->descender)));
+    ftError = FT_Set_Pixel_Sizes(font->font, 0, size);
     return ftError;
 }
 

--- a/fontstash/glfontstash.h
+++ b/fontstash/glfontstash.h
@@ -452,7 +452,7 @@ int glfonsRasterize(FONScontext* ctx, fsuint textId, const char* s, unsigned int
     stash->length = length - 6;
 
     if(ctx->shaping != NULL && fons__getState(ctx)->useShaping) {
-        FONSshapingRes* res = ctx->shaping->shapingRes;
+        FONSshapingRes* res = ctx->shaping->result;
         stash->nbGlyph = res->glyphCount;
         fons__clearShaping(ctx);
     } else {

--- a/fontstash/glfontstash.h
+++ b/fontstash/glfontstash.h
@@ -552,7 +552,9 @@ void glfonsUpdateBuffer(FONScontext* ctx, void* owner) {
     if(gl->params.useGLBackend) {
         if(!buffer->vboInitialized) {
             glBindBuffer(GL_ARRAY_BUFFER, buffer->vbo);
-            GLFONS_GL_CHECK(glBufferData(GL_ARRAY_BUFFER, sizeof(float) * buffer->interleavedArray.size(), data, GL_DYNAMIC_DRAW));
+            GLFONS_GL_CHECK(glBufferData(GL_ARRAY_BUFFER,
+                                         sizeof(float) * buffer->interleavedArray.size(),
+                                         data, GL_DYNAMIC_DRAW));
             glBindBuffer(GL_ARRAY_BUFFER, 0);
             buffer->vboInitialized = true;
             return;


### PR DESCRIPTION
- Fix degenerated codepoints (Related https://github.com/mapzen/eraser-map/issues/101)
- ~~Add library callback for UTF32 (USC-4) conversion~~
- Extend Harfbuzz usage for script/bidi detection

TODO: 
- [x] Extend API for unresolved codepoints fallbacks
- [x] Get the same behavior after this fix https://github.com/tangrams/fontstash-es/commit/600a7df5914e94aeef2a3a488968ff9d881566e1 while using freetype
- [ ] ~~Detect several direction within a given string while using shaping~~
